### PR TITLE
Infer hover from value instead of a separate prop

### DIFF
--- a/src/components/VTooltip/VTooltip.js
+++ b/src/components/VTooltip/VTooltip.js
@@ -20,7 +20,6 @@ export default {
       type: [Number, String],
       default: 0
     },
-    disableHover: Boolean,
     fixed: {
       type: Boolean,
       default: true
@@ -145,7 +144,7 @@ export default {
         }
       }, [tooltip]),
       h('span', {
-        on: this.disableHover ? {} : {
+        on: this.value == null && {
           mouseenter: () => {
             clearTimeout(this.leaveTimeout)
 


### PR DESCRIPTION
Playground.vue:
```html
<template>
  <v-app>
    <main>
      <v-content>
        <v-container fluid>
          <v-tooltip bottom color="primary" :value="value">
            <v-btn slot="activator">Tooltip: {{ value }}</v-btn>
            <span>Tooltip</span>
          </v-tooltip>
          <v-btn @click.stop="value = !value">Toggle tooltip</v-btn>
          <v-btn @click.stop="value = value == null ? false : null">{{ value == null ? 'Disable' : 'Enable' }} tooltip hover</v-btn>
        </v-container>
      </v-content>
    </main>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      value: null
    })
  }
</script>
```